### PR TITLE
Feature/monthly analysis chart view

### DIFF
--- a/client/MEWE/MEWE.xcodeproj/project.pbxproj
+++ b/client/MEWE/MEWE.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		6A27573E25CB0A6C00D8A573 /* NoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A27573D25CB0A6C00D8A573 /* NoticeView.swift */; };
 		6A341C7425CFCD46007FD27A /* HelpBubble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A341C6E25CFCCE4007FD27A /* HelpBubble.framework */; };
 		6A341C7525CFCD46007FD27A /* HelpBubble.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6A341C6E25CFCCE4007FD27A /* HelpBubble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6A7B308B25D39E1800AC17C6 /* MonthlyRepresentativeEmojiView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7B308A25D39E1800AC17C6 /* MonthlyRepresentativeEmojiView.swift */; };
 		6A8DA1CC25B943860027AEAE /* MEWEApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A8DA1CB25B943860027AEAE /* MEWEApp.swift */; };
 		6A8DA1CE25B943860027AEAE /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A8DA1CD25B943860027AEAE /* ContentView.swift */; };
 		6A8DA1D025B943860027AEAE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6A8DA1CF25B943860027AEAE /* Assets.xcassets */; };
@@ -92,6 +93,7 @@
 		6A27573425CB035C00D8A573 /* MonthlyChartViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthlyChartViewModelTests.swift; sourceTree = "<group>"; };
 		6A27573D25CB0A6C00D8A573 /* NoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeView.swift; sourceTree = "<group>"; };
 		6A341C6925CFCCE3007FD27A /* HelpBubble.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = HelpBubble.xcodeproj; path = ../../../Desktop/HelpBubble/HelpBubble.xcodeproj; sourceTree = "<group>"; };
+		6A7B308A25D39E1800AC17C6 /* MonthlyRepresentativeEmojiView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthlyRepresentativeEmojiView.swift; sourceTree = "<group>"; };
 		6A8DA1C825B943860027AEAE /* MEWE.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MEWE.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6A8DA1CB25B943860027AEAE /* MEWEApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MEWEApp.swift; sourceTree = "<group>"; };
 		6A8DA1CD25B943860027AEAE /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -314,6 +316,7 @@
 			children = (
 				6A2756F525CABFD900D8A573 /* MonthlyChartView.swift */,
 				6A27573D25CB0A6C00D8A573 /* NoticeView.swift */,
+				6A7B308A25D39E1800AC17C6 /* MonthlyRepresentativeEmojiView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -587,6 +590,7 @@
 				6A8DA1D525B943860027AEAE /* Persistence.swift in Sources */,
 				6AE137E025CC1F1800D570F1 /* Font.swift in Sources */,
 				5C8DDB5725BC10FA0093580B /* SelectEmoji.swift in Sources */,
+				6A7B308B25D39E1800AC17C6 /* MonthlyRepresentativeEmojiView.swift in Sources */,
 				5C8DDB8325BC20E00093580B /* CategoryView.swift in Sources */,
 				5C93B31525C014300067A723 /* CalendarView.swift in Sources */,
 				5C93B31A25C0143A0067A723 /* UserProfileView.swift in Sources */,

--- a/client/MEWE/MEWE.xcodeproj/project.pbxproj
+++ b/client/MEWE/MEWE.xcodeproj/project.pbxproj
@@ -27,6 +27,9 @@
 		6A341C7425CFCD46007FD27A /* HelpBubble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A341C6E25CFCCE4007FD27A /* HelpBubble.framework */; };
 		6A341C7525CFCD46007FD27A /* HelpBubble.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6A341C6E25CFCCE4007FD27A /* HelpBubble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6A7B308B25D39E1800AC17C6 /* MonthlyRepresentativeEmojiView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7B308A25D39E1800AC17C6 /* MonthlyRepresentativeEmojiView.swift */; };
+		6A7B309625D3A07C00AC17C6 /* MonthlyAnalysisView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7B309525D3A07C00AC17C6 /* MonthlyAnalysisView.swift */; };
+		6A7B309A25D3A3DB00AC17C6 /* MonthlyAnalysisViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7B309925D3A3DB00AC17C6 /* MonthlyAnalysisViewModel.swift */; };
+		6A7B30A425D3A4E200AC17C6 /* EmotionAnalysis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7B30A325D3A4E200AC17C6 /* EmotionAnalysis.swift */; };
 		6A8DA1CC25B943860027AEAE /* MEWEApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A8DA1CB25B943860027AEAE /* MEWEApp.swift */; };
 		6A8DA1CE25B943860027AEAE /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A8DA1CD25B943860027AEAE /* ContentView.swift */; };
 		6A8DA1D025B943860027AEAE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6A8DA1CF25B943860027AEAE /* Assets.xcassets */; };
@@ -94,6 +97,9 @@
 		6A27573D25CB0A6C00D8A573 /* NoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeView.swift; sourceTree = "<group>"; };
 		6A341C6925CFCCE3007FD27A /* HelpBubble.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = HelpBubble.xcodeproj; path = ../../../Desktop/HelpBubble/HelpBubble.xcodeproj; sourceTree = "<group>"; };
 		6A7B308A25D39E1800AC17C6 /* MonthlyRepresentativeEmojiView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthlyRepresentativeEmojiView.swift; sourceTree = "<group>"; };
+		6A7B309525D3A07C00AC17C6 /* MonthlyAnalysisView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthlyAnalysisView.swift; sourceTree = "<group>"; };
+		6A7B309925D3A3DB00AC17C6 /* MonthlyAnalysisViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthlyAnalysisViewModel.swift; sourceTree = "<group>"; };
+		6A7B30A325D3A4E200AC17C6 /* EmotionAnalysis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmotionAnalysis.swift; sourceTree = "<group>"; };
 		6A8DA1C825B943860027AEAE /* MEWE.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MEWE.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6A8DA1CB25B943860027AEAE /* MEWEApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MEWEApp.swift; sourceTree = "<group>"; };
 		6A8DA1CD25B943860027AEAE /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -317,6 +323,7 @@
 				6A2756F525CABFD900D8A573 /* MonthlyChartView.swift */,
 				6A27573D25CB0A6C00D8A573 /* NoticeView.swift */,
 				6A7B308A25D39E1800AC17C6 /* MonthlyRepresentativeEmojiView.swift */,
+				6A7B309525D3A07C00AC17C6 /* MonthlyAnalysisView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -333,6 +340,7 @@
 		6A27570C25CAE3C500D8A573 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				6A7B30A325D3A4E200AC17C6 /* EmotionAnalysis.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -341,6 +349,7 @@
 			isa = PBXGroup;
 			children = (
 				6A27571625CAE47500D8A573 /* MonthlyChartViewModel.swift */,
+				6A7B309925D3A3DB00AC17C6 /* MonthlyAnalysisViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -584,7 +593,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6A7B309625D3A07C00AC17C6 /* MonthlyAnalysisView.swift in Sources */,
 				5C8DDB5C25BC11980093580B /* CircleView.swift in Sources */,
+				6A7B309A25D3A3DB00AC17C6 /* MonthlyAnalysisViewModel.swift in Sources */,
 				5C8DDB4C25BC041D0093580B /* RecordEmojiView.swift in Sources */,
 				5C8DDB7D25BC20660093580B /* TodayEmojiView.swift in Sources */,
 				6A8DA1D525B943860027AEAE /* Persistence.swift in Sources */,
@@ -598,6 +609,7 @@
 				6A27570525CAC1C000D8A573 /* SystemImageName.swift in Sources */,
 				5C8DDB7225BC16610093580B /* Emoji.swift in Sources */,
 				6A8DA1CC25B943860027AEAE /* MEWEApp.swift in Sources */,
+				6A7B30A425D3A4E200AC17C6 /* EmotionAnalysis.swift in Sources */,
 				6A27573E25CB0A6C00D8A573 /* NoticeView.swift in Sources */,
 				6A27571725CAE47500D8A573 /* MonthlyChartViewModel.swift in Sources */,
 				6A2756F625CABFD900D8A573 /* MonthlyChartView.swift in Sources */,

--- a/client/MEWE/MEWE/MonthlyChart/Model/EmotionAnalysis.swift
+++ b/client/MEWE/MEWE/MonthlyChart/Model/EmotionAnalysis.swift
@@ -1,0 +1,16 @@
+//
+//  EmotionAnalysis.swift
+//  MEWE
+//
+//  Created by Keunna Lee on 2021/02/10.
+//
+
+import Foundation
+
+struct EmotionAnalysis: Identifiable {
+    var id: UUID = UUID()
+    
+    let description: String
+    let changes: String
+    let trend: Trend
+}

--- a/client/MEWE/MEWE/MonthlyChart/View/MonthlyAnalysisView.swift
+++ b/client/MEWE/MEWE/MonthlyChart/View/MonthlyAnalysisView.swift
@@ -1,0 +1,46 @@
+//
+//  MonthlyAnalysisView.swift
+//  MEWE
+//
+//  Created by Keunna Lee on 2021/02/10.
+//
+
+import SwiftUI
+
+enum Trend {
+    case uptrend
+    case downtrend
+    case maintain
+}
+
+struct MonthlyAnalysisView: View {
+    
+    @ObservedObject var viewModel = MonthlyAnalysisViewModel()
+    
+    var body: some View {
+        HStack {
+            ForEach(viewModel.analysisData) { data in
+                analysisCellView(data.description, data.changes, data.trend)
+            }
+        }
+    }
+}
+
+extension MonthlyAnalysisView {
+    @ViewBuilder
+    func analysisCellView(_ description: String, _  percentage: String, _ isUp: Trend) -> some View {
+        VStack {
+            Text(description)
+                .setupFont(size: 13, weight: .light, foregroundColor: .gray)
+            HStack {
+                Text(percentage)
+                    .setupFont(size: 15, weight: .bold)
+                switch isUp {
+                case .uptrend: Text("⬆️").setupFont(size: 15, weight: .bold)
+                case .downtrend: Text("⬇️").setupFont(size: 15, weight: .bold)
+                case .maintain: Text("−").setupFont(size: 15, weight: .bold)
+                }
+            }
+        }
+    }
+}

--- a/client/MEWE/MEWE/MonthlyChart/View/MonthlyAnalysisView.swift
+++ b/client/MEWE/MEWE/MonthlyChart/View/MonthlyAnalysisView.swift
@@ -28,19 +28,25 @@ struct MonthlyAnalysisView: View {
 
 extension MonthlyAnalysisView {
     @ViewBuilder
-    func analysisCellView(_ description: String, _  percentage: String, _ isUp: Trend) -> some View {
+    private func analysisCellView(_ description: String, _  percentage: String, _ trend: Trend) -> some View {
         VStack {
             Text(description)
                 .setupFont(size: 13, weight: .light, foregroundColor: .gray)
             HStack {
                 Text(percentage)
                     .setupFont(size: 15, weight: .bold)
-                switch isUp {
-                case .uptrend: Text("⬆️").setupFont(size: 15, weight: .bold)
-                case .downtrend: Text("⬇️").setupFont(size: 15, weight: .bold)
-                case .maintain: Text("−").setupFont(size: 15, weight: .bold)
-                }
+                trendView(trend)
+                    .setupFont(size: 15, weight: .bold)
             }
+        }
+    }
+    
+    @ViewBuilder
+    private func trendView(_ trend: Trend) -> some View {
+        switch trend {
+        case .uptrend: Text("⬆️")
+        case .downtrend: Text("⬇️")
+        case .maintain: Text("−")
         }
     }
 }

--- a/client/MEWE/MEWE/MonthlyChart/View/MonthlyChartView.swift
+++ b/client/MEWE/MEWE/MonthlyChart/View/MonthlyChartView.swift
@@ -70,7 +70,7 @@ struct MonthlyChartView: View {
                         }
                     }
                     
-                    
+                    MonthlyRepresentativeEmojiView()
                     Spacer()
                     Spacer()
                 }

--- a/client/MEWE/MEWE/MonthlyChart/View/MonthlyChartView.swift
+++ b/client/MEWE/MEWE/MonthlyChart/View/MonthlyChartView.swift
@@ -17,7 +17,7 @@ struct MonthlyChartView: View {
             NavigationView {
                 VStack {
                     
-                    // Navigation
+                    // MARK: - Navigation
                     HStack {
                         NavigationLink(destination: CalendarView()){
                             Image(systemName: SystemImageName.chevronLeft)
@@ -35,7 +35,7 @@ struct MonthlyChartView: View {
                     
                     Spacer()
                     
-                    // Select Month
+                    // MARK: - Select Month
                     HStack {
                         
                         Button(action: { // move to previous buttonUIScreen
@@ -56,12 +56,12 @@ struct MonthlyChartView: View {
                         })
                         
                     }
-                    
-                    // Chart
+                    VStack {
+                    // MARK: - Chart
                     ZStack {
                         
                         LineView(data: viewModel.lineChartdata, title: viewModel.sceneTitle, legend: "이번 달 감정 변화를 확인하세요 👀")
-                            .padding()
+                            .padding(10)
                         
                         // notice view - not enough data
                         if viewModel.lineChartdata.count < 10 {
@@ -70,9 +70,16 @@ struct MonthlyChartView: View {
                         }
                     }
                     
+                    // MARK: - monthly representative emoji
                     MonthlyRepresentativeEmojiView()
-                    Spacer()
-                    Spacer()
+                        .frame(width: geometry.size.width - 10, height: 100, alignment: /*@START_MENU_TOKEN@*/.center/*@END_MENU_TOKEN@*/)
+                    
+                    // MARK: - monthly analysis
+                    MonthlyAnalysisView()
+                        .frame(width: geometry.size.width, height: 100, alignment: /*@START_MENU_TOKEN@*/.center/*@END_MENU_TOKEN@*/)
+                    
+                }
+                    .frame(maxHeight: .infinity)
                 }
                 .navigationBarHidden(true)
             }

--- a/client/MEWE/MEWE/MonthlyChart/View/MonthlyChartView.swift
+++ b/client/MEWE/MEWE/MonthlyChart/View/MonthlyChartView.swift
@@ -60,33 +60,17 @@ struct MonthlyChartView: View {
                     // Chart
                     ZStack {
                         
-                        // 디자인에 따라 bar chart 와 pie chart 중 하나 사용할 예정입니다
-                        BarChartView(data: viewModel.barChartData,
-                                     title: viewModel.sceneTitle,
-                                     style: barChartStyle,
-                                     form: CGSize(width: geometry.size.width - 100,
-                                                  height: geometry.size.height / 3))
-                        
-                        PieChartView(data: viewModel.pieChartdata,
-                                     title: "월말 정산",
-                                     legend: "한 달동안 어떤 감정을 느끼셨나요?",
-                                     style: .init(backgroundColor: .white,
-                                                  accentColor: .yellow,
-                                                  secondGradientColor: .green,
-                                                  textColor: .black,
-                                                  legendTextColor: .gray,
-                                                  dropShadowColor: .black),
-                                     form: CGSize(width: geometry.size.width - 100,
-                                                  height: geometry.size.height / 3),
-                                     dropShadow: true,
-                                     valueSpecifier: " ☺️ ")
+                        LineView(data: viewModel.lineChartdata, title: viewModel.sceneTitle, legend: "이번 달 감정 변화를 확인하세요 👀")
+                            .padding()
                         
                         // notice view - not enough data
-                        if viewModel.pieChartdata.count < 10 {
+                        if viewModel.lineChartdata.count < 10 {
                             NoticeView(width: geometry.size.width - 100, height: geometry.size.height / 3)
                                 .cornerRadius(30)
                         }
                     }
+                    
+                    
                     Spacer()
                     Spacer()
                 }

--- a/client/MEWE/MEWE/MonthlyChart/View/MonthlyRepresentativeEmojiView.swift
+++ b/client/MEWE/MEWE/MonthlyChart/View/MonthlyRepresentativeEmojiView.swift
@@ -1,0 +1,29 @@
+//
+//  MonthlyRepresentativeEmojiView.swift
+//  MEWE
+//
+//  Created by Keunna Lee on 2021/02/10.
+//
+
+import SwiftUI
+
+struct MonthlyRepresentativeEmojiView: View {
+    var body: some View {
+        HStack {
+            Text("이달의 대표 감정")
+            Button(action: {}){
+                   VStack{
+                    Text("행복")
+                        .setupFont(size: 20, weight: .bold)
+                    Text("+4%")
+                        .setupFont(size: 15, weight: .light, foregroundColor: .white)
+                   }
+                   .padding(40)
+                   .background(Color.orange)
+                   .font(.headline)
+                   .mask(Circle())
+               }
+               .buttonStyle(PlainButtonStyle())
+        }
+    }
+}

--- a/client/MEWE/MEWE/MonthlyChart/ViewModel/MonthlyAnalysisViewModel.swift
+++ b/client/MEWE/MEWE/MonthlyChart/ViewModel/MonthlyAnalysisViewModel.swift
@@ -1,0 +1,12 @@
+//
+//  MonthlyAnalysisViewModel.swift
+//  MEWE
+//
+//  Created by Keunna Lee on 2021/02/10.
+//
+
+import Foundation
+
+class MonthlyAnalysisViewModel: ObservableObject{
+    @Published var analysisData: [EmotionAnalysis] =  [EmotionAnalysis(description: "지난달보다 \n긍정적 감정이", changes: "34%", trend: .uptrend), EmotionAnalysis(description: "지난달보다 \n부정적 감정이", changes: "21%", trend: .downtrend), EmotionAnalysis(description: "지난달보다 \n감정 표현 횟수가", changes: "4.5%", trend: .uptrend)]
+}

--- a/client/MEWE/MEWE/MonthlyChart/ViewModel/MonthlyChartViewModel.swift
+++ b/client/MEWE/MEWE/MonthlyChart/ViewModel/MonthlyChartViewModel.swift
@@ -14,8 +14,7 @@ class MonthlyChartViewModel: ObservableObject {
     private let january: Int = 1
     private let december: Int = 12
     private(set) var sceneTitle: String = "월말정산"
-    @Published var pieChartdata: [Double] =  [8,23,54,32,12,37,7,23,43]
-    @Published var barChartData: ChartData = ChartData(values: [(" 😀 ", 12), (" 🤩 ", 13), (" 👻 ", 30), (" 😶 ", 11), (" 🤯 ", 3), (" 😭 ", 6), (" 🥺 ", 6), (" 🥳 ", 20), (" 😬 ", 5), (" 😫 ", 15)])
+    @Published var lineChartdata: [Double] =  [8,23,54,32,12,37,7,23,43]
     @Published var currentMonth: Int = 0
     @Published var currentYear: Int = 0
     
@@ -26,7 +25,7 @@ class MonthlyChartViewModel: ObservableObject {
 // MARK: - ChartData
 extension MonthlyChartViewModel {
     func updateChartData() {
-        self.pieChartdata = pieChartdata.shuffled() // 추후 네트워크 연결 후 서버에서 받아온 데이터를 사용하여 수정할 예정입니다.
+        self.lineChartdata = lineChartdata.shuffled() // 추후 네트워크 연결 후 서버에서 받아온 데이터를 사용하여 수정할 예정입니다.
     }
 }
 


### PR DESCRIPTION
### 구현 화면
<img src="https://user-images.githubusercontent.com/52783516/107470609-0444d200-6baf-11eb-877a-7eccafae576d.png" alt="image" width="33%;" /><img src="https://user-images.githubusercontent.com/52783516/107470695-250d2780-6baf-11eb-9ff3-c1bf3491f6cf.png" alt="image" width="33%;" />

### 변경 사항
1. 지난 회의 때 라인 그래프로 하기로 결정되어서 그래프를 Line Graph로 변경하였습니다

### 구현 기능
1. 월말 정산 하단부에 **이달의 대표 감정**을 나타내는 뷰를 구현했습니다.
2. 이달의 대표 감정 아래 **지난달과 긍정적 감정 / 부정적 감정 / 감정 표현 횟수를 비교한 수치**를 나타내주는 뷰를 구현했습니다.

### 추후 반영 사항
1. Json 타입에 따라 각 view에 필요한 Model을 변경할 예정입니다 (`EmotionAnalysis` 구조체 등)