### PR TITLE
Feature / reopen HelpChatBubble library file

### DIFF
--- a/client/MEWE/HelpBubble/HelpBubble.xcodeproj/project.pbxproj
+++ b/client/MEWE/HelpBubble/HelpBubble.xcodeproj/project.pbxproj
@@ -1,0 +1,343 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		6A74A3AF25CFE5F300235306 /* HelpChatBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A74A3AE25CFE5F300235306 /* HelpChatBubbleView.swift */; };
+		6A94405725DBB2E40097826A /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 6A341C6225CFCCE3007FD27A /* Info.plist */; };
+		6A94405925DBB2E70097826A /* HelpBubble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A341C5E25CFCCE3007FD27A /* HelpBubble.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		6A341C5E25CFCCE3007FD27A /* HelpBubble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = HelpBubble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6A341C6225CFCCE3007FD27A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6A74A3AE25CFE5F300235306 /* HelpChatBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpChatBubbleView.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		6A341C5B25CFCCE3007FD27A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6A94405925DBB2E70097826A /* HelpBubble.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		6A341C5425CFCCE3007FD27A = {
+			isa = PBXGroup;
+			children = (
+				6A341C6025CFCCE3007FD27A /* HelpBubble */,
+				6A341C5F25CFCCE3007FD27A /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		6A341C5F25CFCCE3007FD27A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				6A341C5E25CFCCE3007FD27A /* HelpBubble.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		6A341C6025CFCCE3007FD27A /* HelpBubble */ = {
+			isa = PBXGroup;
+			children = (
+				6A341C6225CFCCE3007FD27A /* Info.plist */,
+				6A74A3AE25CFE5F300235306 /* HelpChatBubbleView.swift */,
+			);
+			path = HelpBubble;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		6A341C5925CFCCE3007FD27A /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		6A341C5D25CFCCE3007FD27A /* HelpBubble */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6A341C6625CFCCE3007FD27A /* Build configuration list for PBXNativeTarget "HelpBubble" */;
+			buildPhases = (
+				6A341C5925CFCCE3007FD27A /* Headers */,
+				6A341C5A25CFCCE3007FD27A /* Sources */,
+				6A341C5B25CFCCE3007FD27A /* Frameworks */,
+				6A341C5C25CFCCE3007FD27A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelpBubble;
+			productName = HelpBubble;
+			productReference = 6A341C5E25CFCCE3007FD27A /* HelpBubble.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		6A341C5525CFCCE3007FD27A /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1220;
+				TargetAttributes = {
+					6A341C5D25CFCCE3007FD27A = {
+						CreatedOnToolsVersion = 12.2;
+						LastSwiftMigration = 1220;
+					};
+				};
+			};
+			buildConfigurationList = 6A341C5825CFCCE3007FD27A /* Build configuration list for PBXProject "HelpBubble" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 6A341C5425CFCCE3007FD27A;
+			productRefGroup = 6A341C5F25CFCCE3007FD27A /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				6A341C5D25CFCCE3007FD27A /* HelpBubble */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		6A341C5C25CFCCE3007FD27A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6A94405725DBB2E40097826A /* Info.plist in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		6A341C5A25CFCCE3007FD27A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6A74A3AF25CFE5F300235306 /* HelpChatBubbleView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		6A341C6425CFCCE3007FD27A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.2;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		6A341C6525CFCCE3007FD27A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		6A341C6725CFCCE3007FD27A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 93A6S4WHC4;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = HelpBubble/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.lena.HelpBubble;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		6A341C6825CFCCE3007FD27A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 93A6S4WHC4;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = HelpBubble/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.lena.HelpBubble;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		6A341C5825CFCCE3007FD27A /* Build configuration list for PBXProject "HelpBubble" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6A341C6425CFCCE3007FD27A /* Debug */,
+				6A341C6525CFCCE3007FD27A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6A341C6625CFCCE3007FD27A /* Build configuration list for PBXNativeTarget "HelpBubble" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6A341C6725CFCCE3007FD27A /* Debug */,
+				6A341C6825CFCCE3007FD27A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 6A341C5525CFCCE3007FD27A /* Project object */;
+}

--- a/client/MEWE/HelpBubble/HelpBubble/HelpChatBubbleView.swift
+++ b/client/MEWE/HelpBubble/HelpBubble/HelpChatBubbleView.swift
@@ -1,0 +1,53 @@
+//
+//  HelpChatBubbleView.swift
+//  HelpBubble
+//
+//  Created by Keunna Lee on 2021/02/07.
+//
+
+import SwiftUI
+
+/*
+ 도움말 말풍선을 나타내는 View입니다.
+ */
+
+public enum BubblePosition {
+    case left
+    case right
+}
+
+public struct HelpChatBubbleView<Content>: View where Content: View {
+    
+    public typealias MessageText = String
+    public let position: BubblePosition
+    public let color : Color
+    public let content: () -> Content
+    
+    public init(position: BubblePosition,
+                color: Color, @ViewBuilder
+                content: @escaping () -> Content) {
+        self.content = content
+        self.position = position
+        self.color = color
+     }
+    
+    public var body: some View {
+        HStack(spacing: 0 ) {
+            content()
+                .padding(.all, 15)
+                .foregroundColor(Color.white)
+                .background(color)
+                .clipShape(RoundedRectangle(cornerRadius: 18))
+                .overlay(
+                    Image(systemName: "arrowtriangle.left.fill")
+                        .foregroundColor(color)
+                        .rotationEffect(Angle(degrees: position == .left ? -50 : -130))
+                        .offset(x: position == .left ? -5 : 5)
+                    ,alignment: position == .left ? .bottomLeading : .bottomTrailing)
+        }
+        .padding(position == .left ? .leading : .trailing , 15)
+        .padding(position == .right ? .leading : .trailing , 60)
+        .frame(width: UIScreen.main.bounds.width, alignment: position == .left ? .leading : .trailing)
+    }
+    
+}

--- a/client/MEWE/HelpBubble/HelpBubble/Info.plist
+++ b/client/MEWE/HelpBubble/HelpBubble/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/client/MEWE/MEWE.xcodeproj/project.pbxproj
+++ b/client/MEWE/MEWE.xcodeproj/project.pbxproj
@@ -24,8 +24,6 @@
 		6A27573525CB035C00D8A573 /* MonthlyChartViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A27573425CB035C00D8A573 /* MonthlyChartViewModelTests.swift */; };
 		6A27573925CB048700D8A573 /* MonthlyChartViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A27571625CAE47500D8A573 /* MonthlyChartViewModel.swift */; };
 		6A27573E25CB0A6C00D8A573 /* NoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A27573D25CB0A6C00D8A573 /* NoticeView.swift */; };
-		6A341C7425CFCD46007FD27A /* HelpBubble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A341C6E25CFCCE4007FD27A /* HelpBubble.framework */; };
-		6A341C7525CFCD46007FD27A /* HelpBubble.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6A341C6E25CFCCE4007FD27A /* HelpBubble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6A7B308B25D39E1800AC17C6 /* MonthlyRepresentativeEmojiView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7B308A25D39E1800AC17C6 /* MonthlyRepresentativeEmojiView.swift */; };
 		6A7B309625D3A07C00AC17C6 /* MonthlyAnalysisView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7B309525D3A07C00AC17C6 /* MonthlyAnalysisView.swift */; };
 		6A7B309A25D3A3DB00AC17C6 /* MonthlyAnalysisViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7B309925D3A3DB00AC17C6 /* MonthlyAnalysisViewModel.swift */; };
@@ -42,13 +40,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		6A341C6D25CFCCE4007FD27A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6A341C6925CFCCE3007FD27A /* HelpBubble.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 6A341C5E25CFCCE3007FD27A;
-			remoteInfo = HelpBubble;
-		};
 		6A8DA1DF25B943870027AEAE /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 6A8DA1C025B943860027AEAE /* Project object */;
@@ -63,6 +54,13 @@
 			remoteGlobalIDString = 6A8DA1C725B943860027AEAE;
 			remoteInfo = MEWE;
 		};
+		6A94405225DBB2A70097826A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6A341C6925CFCCE3007FD27A /* HelpBubble.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 6A341C5E25CFCCE3007FD27A;
+			remoteInfo = HelpBubble;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -72,7 +70,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				6A341C7525CFCD46007FD27A /* HelpBubble.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -95,7 +92,7 @@
 		6A27571625CAE47500D8A573 /* MonthlyChartViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthlyChartViewModel.swift; sourceTree = "<group>"; };
 		6A27573425CB035C00D8A573 /* MonthlyChartViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthlyChartViewModelTests.swift; sourceTree = "<group>"; };
 		6A27573D25CB0A6C00D8A573 /* NoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeView.swift; sourceTree = "<group>"; };
-		6A341C6925CFCCE3007FD27A /* HelpBubble.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = HelpBubble.xcodeproj; path = ../../../Desktop/HelpBubble/HelpBubble.xcodeproj; sourceTree = "<group>"; };
+		6A341C6925CFCCE3007FD27A /* HelpBubble.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = HelpBubble.xcodeproj; path = HelpBubble/HelpBubble.xcodeproj; sourceTree = "<group>"; };
 		6A7B308A25D39E1800AC17C6 /* MonthlyRepresentativeEmojiView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthlyRepresentativeEmojiView.swift; sourceTree = "<group>"; };
 		6A7B309525D3A07C00AC17C6 /* MonthlyAnalysisView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthlyAnalysisView.swift; sourceTree = "<group>"; };
 		6A7B309925D3A3DB00AC17C6 /* MonthlyAnalysisViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthlyAnalysisViewModel.swift; sourceTree = "<group>"; };
@@ -123,7 +120,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				6A27572525CAFB2300D8A573 /* SwiftUICharts in Frameworks */,
-				6A341C7425CFCD46007FD27A /* HelpBubble.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -354,14 +350,6 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
-		6A341C6A25CFCCE3007FD27A /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				6A341C6E25CFCCE4007FD27A /* HelpBubble.framework */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		6A341C7325CFCD46007FD27A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -439,6 +427,14 @@
 				6A8DA1EF25B943870027AEAE /* Info.plist */,
 			);
 			path = MEWEUITests;
+			sourceTree = "<group>";
+		};
+		6A94404F25DBB2A70097826A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				6A94405325DBB2A70097826A /* HelpBubble.framework */,
+			);
+			name = Products;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -539,7 +535,7 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProductGroup = 6A341C6A25CFCCE3007FD27A /* Products */;
+					ProductGroup = 6A94404F25DBB2A70097826A /* Products */;
 					ProjectRef = 6A341C6925CFCCE3007FD27A /* HelpBubble.xcodeproj */;
 				},
 			);
@@ -553,11 +549,11 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		6A341C6E25CFCCE4007FD27A /* HelpBubble.framework */ = {
+		6A94405325DBB2A70097826A /* HelpBubble.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = HelpBubble.framework;
-			remoteRef = 6A341C6D25CFCCE4007FD27A /* PBXContainerItemProxy */;
+			remoteRef = 6A94405225DBB2A70097826A /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */


### PR DESCRIPTION
지난 회의때 정현님(디자이너)이 MEWE 앱에 말풍선 뷰가 전반적으로 많이 들어간다고 하셔서
모든 화면에서 import 해서 바로 사용할 수 있도록 도움말 말풍선 뷰를 프레임워크로 만들었습니다! 🥳

## 구현한 라이브러리
### HelpBubbleChatView
- MEWE.xcodeproj 안에 추가 되어있습니다.
- 말풍선 꼬리 방향 선택 가능합니다. (왼쪽, 오른쪽)
- 뷰 생성시마다 메세지 설정 가능합니다.

### 사용 방법
```swift
import HelpBubble

struct SampleView: View {
  var body: some View {
        HelpChatBubbleView(position: .left, color: .blue) {
            Text("지난 감정 기록을 확인해보세요!")
        }
  }
}
```

![image](https://user-images.githubusercontent.com/52783516/107142824-c6f50000-6974-11eb-810c-2962387c0a97.png)
  ![image](https://user-images.githubusercontent.com/52783516/107142805-b0e73f80-6974-11eb-9b83-c37548ff1957.png)

related PR: #12 (commit을 확인할 수 있습니다)
related issue: #11 