### PR TITLE
Feature/ front rounded bottom navigation view

### DIFF
--- a/client/MEWE/MEWE.xcodeproj/project.pbxproj
+++ b/client/MEWE/MEWE.xcodeproj/project.pbxproj
@@ -38,6 +38,8 @@
 		6A8DA1D825B943860027AEAE /* MEWE.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 6A8DA1D625B943860027AEAE /* MEWE.xcdatamodeld */; };
 		6A8DA1E325B943870027AEAE /* MEWETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A8DA1E225B943870027AEAE /* MEWETests.swift */; };
 		6A8DA1EE25B943870027AEAE /* MEWEUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A8DA1ED25B943870027AEAE /* MEWEUITests.swift */; };
+		6AD0D09125E3D28500E736E1 /* RoundedBottomNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD0D09025E3D28500E736E1 /* RoundedBottomNavigationView.swift */; };
+		6AD0D09725E3D2FA00E736E1 /* EmojiMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD0D09625E3D2FA00E736E1 /* EmojiMapView.swift */; };
 		6AE137E025CC1F1800D570F1 /* Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AE137DF25CC1F1800D570F1 /* Font.swift */; };
 /* End PBXBuildFile section */
 
@@ -114,6 +116,8 @@
 		6A8DA1E925B943870027AEAE /* MEWEUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MEWEUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6A8DA1ED25B943870027AEAE /* MEWEUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MEWEUITests.swift; sourceTree = "<group>"; };
 		6A8DA1EF25B943870027AEAE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6AD0D09025E3D28500E736E1 /* RoundedBottomNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedBottomNavigationView.swift; sourceTree = "<group>"; };
+		6AD0D09625E3D2FA00E736E1 /* EmojiMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiMapView.swift; sourceTree = "<group>"; };
 		6AE137DF25CC1F1800D570F1 /* Font.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Font.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -402,6 +406,7 @@
 				6A8DA1D625B943860027AEAE /* MEWE.xcdatamodeld */,
 				6A27570325CAC1A700D8A573 /* Utility */,
 				5C8DDB7125BC16610093580B /* Emoji.swift */,
+				6AD0D08C25E3D24200E736E1 /* Common */,
 				5C93B30E25C013CC0067A723 /* Friend */,
 				5C75378725DBCEE90025687E /* Tab */,
 				5C93B30D25C0139D0067A723 /* UserProfile */,
@@ -410,6 +415,7 @@
 				5C8DDB8125BC20C20093580B /* Category */,
 				5C8DDB4A25BC03FA0093580B /* Today */,
 				6A2756F325CABFB000D8A573 /* MonthlyChart */,
+				6AD0D08E25E3D25700E736E1 /* EmojiMap */,
 				6A8DA1D125B943860027AEAE /* Preview Content */,
 			);
 			path = MEWE;
@@ -448,6 +454,30 @@
 				6A94405325DBB2A70097826A /* HelpBubble.framework */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		6AD0D08C25E3D24200E736E1 /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				6AD0D09025E3D28500E736E1 /* RoundedBottomNavigationView.swift */,
+			);
+			path = Common;
+			sourceTree = "<group>";
+		};
+		6AD0D08E25E3D25700E736E1 /* EmojiMap */ = {
+			isa = PBXGroup;
+			children = (
+				6AD0D08F25E3D26100E736E1 /* View */,
+			);
+			path = EmojiMap;
+			sourceTree = "<group>";
+		};
+		6AD0D08F25E3D26100E736E1 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				6AD0D09625E3D2FA00E736E1 /* EmojiMapView.swift */,
+			);
+			path = View;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -611,6 +641,7 @@
 				5C8DDB7D25BC20660093580B /* TodayEmojiView.swift in Sources */,
 				6A8DA1D525B943860027AEAE /* Persistence.swift in Sources */,
 				6AE137E025CC1F1800D570F1 /* Font.swift in Sources */,
+				6AD0D09125E3D28500E736E1 /* RoundedBottomNavigationView.swift in Sources */,
 				5C8DDB5725BC10FA0093580B /* SelectEmoji.swift in Sources */,
 				6A7B308B25D39E1800AC17C6 /* MonthlyRepresentativeEmojiView.swift in Sources */,
 				5C8DDB8325BC20E00093580B /* CategoryView.swift in Sources */,
@@ -627,6 +658,7 @@
 				6A2756F625CABFD900D8A573 /* MonthlyChartView.swift in Sources */,
 				5C8DDB4625BC03830093580B /* TodayView.swift in Sources */,
 				5C93B31F25C014420067A723 /* FriendView.swift in Sources */,
+				6AD0D09725E3D2FA00E736E1 /* EmojiMapView.swift in Sources */,
 				6A8DA1D825B943860027AEAE /* MEWE.xcdatamodeld in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/client/MEWE/MEWE/Common/RoundedBottomNavigationView.swift
+++ b/client/MEWE/MEWE/Common/RoundedBottomNavigationView.swift
@@ -1,0 +1,88 @@
+//
+//  RoundedBottomNavigationView.swift
+//  MEWE
+//
+//  Created by Keunna Lee on 2021/02/22.
+//
+
+import SwiftUI
+
+struct RoundedBottomNavigationView<Content: View, Destination : View>: View {
+    let destination : Destination
+    let isRoot : Bool
+    let isLast : Bool
+    let color : Color
+    let content: Content
+    @State var active = false
+    @Environment(\.presentationMode) var mode: Binding<PresentationMode>
+    
+    init(destination: Destination,
+         isRoot : Bool,
+         isLast : Bool,
+         color : Color,
+         @ViewBuilder titleContent: () -> Content) {
+        self.destination = destination
+        self.isRoot = isRoot
+        self.isLast = isLast
+        self.color = color
+        self.content = titleContent()
+    }
+    
+    var body: some View {
+        NavigationView {
+            GeometryReader { geometry in
+                Color.white
+                VStack {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 25, style: .continuous)
+                                        .fill(Color.white)
+                            .frame(width: geometry.size.width, height: 100)
+                            .mask(RoundedRectangle(cornerRadius: 25, style: .continuous))
+                            .shadow(color: Color(UIColor.lightGray), radius: 5, x: 0, y: 5)
+                                .edgesIgnoringSafeArea(.top)
+                        Spacer()
+                        HStack {
+                            // Back Button
+                            Image(systemName: SystemImageName.arrowLeft)
+                                    .frame(width: 20)
+                                    .foregroundColor(.black)
+                                .onTapGesture(count: 1, perform: {
+                                    self.mode.wrappedValue.dismiss()
+                                }).opacity(isRoot ? 0 : 1)
+                            Spacer()
+                            
+                            // Title
+                            self.content
+                            
+                            // Next Button
+                            Spacer()
+                            Image(systemName: SystemImageName.arrowRight)
+                                .frame(width: 20)
+                                .foregroundColor(.black)
+                                .onTapGesture(count: 1, perform: {
+                                    self.active.toggle()
+                                })
+                                .opacity(isLast ? 0 : 1)
+                            
+                            NavigationLink(
+                                destination: destination.navigationBarHidden(true)
+                                    .navigationBarHidden(true),
+                                isActive: self.$active,
+                                label: {
+                                    //no label
+                                })
+                        }
+                        .padding([.leading,.trailing], 15)
+                        .padding(.top, 50)
+                        .frame(width: geometry.size.width)
+                        .font(.system(size: 22))
+
+                    }
+                    .frame(width: geometry.size.width, height: 90)
+                    .edgesIgnoringSafeArea(.top)
+                }
+            }.navigationBarHidden(true)
+        }
+    }
+}
+

--- a/client/MEWE/MEWE/EmojiMap/View/EmojiMapView.swift
+++ b/client/MEWE/MEWE/EmojiMap/View/EmojiMapView.swift
@@ -1,0 +1,20 @@
+//
+//  EmojiMapView.swift
+//  MEWE
+//
+//  Created by Keunna Lee on 2021/02/22.
+//
+
+import SwiftUI
+
+struct EmojiMapView: View {
+    var body: some View {
+        RoundedBottomNavigationView(destination: TodayView(),
+                                    isRoot: false,
+                                    isLast: true,
+                                    color: .white) {
+            Text("18 April 2019")
+                .setupFont(size: 15, weight: .regular)
+        }
+    }
+}

--- a/client/MEWE/MEWE/Utility/SystemImageName.swift
+++ b/client/MEWE/MEWE/Utility/SystemImageName.swift
@@ -10,4 +10,6 @@ import Foundation
 enum SystemImageName {
     static let chevronLeft = "chevron.left"
     static let chevronRight = "chevron.right"
+    static let arrowLeft = "arrow.left"
+    static let arrowRight = "arrow.right"
 }


### PR DESCRIPTION
## 구현 화면

<img src = "https://user-images.githubusercontent.com/52783516/108705797-19c3df80-7551-11eb-9c91-77533b7737c7.png" width = "40%">

## 구현 내용
월말 정산, 나의 정보, 감정 지도에서 공통적으로 사용되는 rounded bottom navigation view를 구현했습니다.
공통으로 사용할 수 있는 view라서 Common이라는 그룹을 새로 만들어 그곳에 파일을 위치시켰습니다.

## 사용 방법
```swift
        RoundedBottomNavigationView(destination: TodayView(), // 다음 화면
                                    isRoot: false, // true일 경우 ← (back) 버튼 비활성화
                                    isLast: true, // true일 경우 → (next) 버튼 비활성화
                                    color: .white) { // 바탕색
            Text("18 April 2019") // navigation view의 Title에 들어갈 view
        }
```
