### PR TITLE
Feature/ search bar & show bottom sheet when date in navigation bar is tapped (Emoji Map View)

### DIFF
--- a/client/MEWE/MEWE.xcodeproj/project.pbxproj
+++ b/client/MEWE/MEWE.xcodeproj/project.pbxproj
@@ -38,6 +38,8 @@
 		6A8DA1D825B943860027AEAE /* MEWE.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 6A8DA1D625B943860027AEAE /* MEWE.xcdatamodeld */; };
 		6A8DA1E325B943870027AEAE /* MEWETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A8DA1E225B943870027AEAE /* MEWETests.swift */; };
 		6A8DA1EE25B943870027AEAE /* MEWEUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A8DA1ED25B943870027AEAE /* MEWEUITests.swift */; };
+		6AC1933525E407F000C8BBA3 /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC1933425E407F000C8BBA3 /* SearchBar.swift */; };
+		6AC1933F25E4165B00C8BBA3 /* CalendarSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC1933E25E4165B00C8BBA3 /* CalendarSheetView.swift */; };
 		6AD0D09125E3D28500E736E1 /* RoundedBottomNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD0D09025E3D28500E736E1 /* RoundedBottomNavigationView.swift */; };
 		6AD0D09725E3D2FA00E736E1 /* EmojiMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD0D09625E3D2FA00E736E1 /* EmojiMapView.swift */; };
 		6AE137E025CC1F1800D570F1 /* Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AE137DF25CC1F1800D570F1 /* Font.swift */; };
@@ -116,6 +118,8 @@
 		6A8DA1E925B943870027AEAE /* MEWEUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MEWEUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6A8DA1ED25B943870027AEAE /* MEWEUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MEWEUITests.swift; sourceTree = "<group>"; };
 		6A8DA1EF25B943870027AEAE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6AC1933425E407F000C8BBA3 /* SearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBar.swift; sourceTree = "<group>"; };
+		6AC1933E25E4165B00C8BBA3 /* CalendarSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarSheetView.swift; sourceTree = "<group>"; };
 		6AD0D09025E3D28500E736E1 /* RoundedBottomNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedBottomNavigationView.swift; sourceTree = "<group>"; };
 		6AD0D09625E3D2FA00E736E1 /* EmojiMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiMapView.swift; sourceTree = "<group>"; };
 		6AE137DF25CC1F1800D570F1 /* Font.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Font.swift; sourceTree = "<group>"; };
@@ -476,6 +480,8 @@
 			isa = PBXGroup;
 			children = (
 				6AD0D09625E3D2FA00E736E1 /* EmojiMapView.swift */,
+				6AC1933425E407F000C8BBA3 /* SearchBar.swift */,
+				6AC1933E25E4165B00C8BBA3 /* CalendarSheetView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -634,6 +640,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6AC1933F25E4165B00C8BBA3 /* CalendarSheetView.swift in Sources */,
 				6A7B309625D3A07C00AC17C6 /* MonthlyAnalysisView.swift in Sources */,
 				5C8DDB5C25BC11980093580B /* CircleView.swift in Sources */,
 				6A7B309A25D3A3DB00AC17C6 /* MonthlyAnalysisViewModel.swift in Sources */,
@@ -648,6 +655,7 @@
 				5C75378925DBCF0D0025687E /* TabsView.swift in Sources */,
 				5C93B31525C014300067A723 /* CalendarView.swift in Sources */,
 				5C93B31A25C0143A0067A723 /* UserProfileView.swift in Sources */,
+				6AC1933525E407F000C8BBA3 /* SearchBar.swift in Sources */,
 				6A8DA1CE25B943860027AEAE /* ContentView.swift in Sources */,
 				6A27570525CAC1C000D8A573 /* SystemImageName.swift in Sources */,
 				5C8DDB7225BC16610093580B /* Emoji.swift in Sources */,

--- a/client/MEWE/MEWE/Common/RoundedBottomNavigationView.swift
+++ b/client/MEWE/MEWE/Common/RoundedBottomNavigationView.swift
@@ -13,19 +13,25 @@ struct RoundedBottomNavigationView<Content: View, Destination : View>: View {
     let isLast : Bool
     let color : Color
     let content: Content
+    let backButtonImageName: String
+    let nextButtonImageName: String
     @State var active = false
     @Environment(\.presentationMode) var mode: Binding<PresentationMode>
     
     init(destination: Destination,
          isRoot : Bool,
          isLast : Bool,
-         color : Color,
-         @ViewBuilder titleContent: () -> Content) {
+         color : Color = .black,
+         backButtonImageName: String = SystemImageName.arrowLeft,
+         nextButtonImageName: String = SystemImageName.arrowRight,
+         @ViewBuilder content: () -> Content) {
         self.destination = destination
         self.isRoot = isRoot
         self.isLast = isLast
         self.color = color
-        self.content = titleContent()
+        self.backButtonImageName = backButtonImageName
+        self.nextButtonImageName = nextButtonImageName
+        self.content = content()
     }
     
     var body: some View {
@@ -43,9 +49,9 @@ struct RoundedBottomNavigationView<Content: View, Destination : View>: View {
                         Spacer()
                         HStack {
                             // Back Button
-                            Image(systemName: SystemImageName.arrowLeft)
+                            Image(systemName: backButtonImageName)
                                     .frame(width: 20)
-                                    .foregroundColor(.black)
+                                    .foregroundColor(color)
                                 .onTapGesture(count: 1, perform: {
                                     self.mode.wrappedValue.dismiss()
                                 }).opacity(isRoot ? 0 : 1)
@@ -56,9 +62,9 @@ struct RoundedBottomNavigationView<Content: View, Destination : View>: View {
                             
                             // Next Button
                             Spacer()
-                            Image(systemName: SystemImageName.arrowRight)
+                            Image(systemName: nextButtonImageName)
                                 .frame(width: 20)
-                                .foregroundColor(.black)
+                                .foregroundColor(color)
                                 .onTapGesture(count: 1, perform: {
                                     self.active.toggle()
                                 })

--- a/client/MEWE/MEWE/EmojiMap/View/CalendarSheetView.swift
+++ b/client/MEWE/MEWE/EmojiMap/View/CalendarSheetView.swift
@@ -1,0 +1,19 @@
+//
+//  CalendarSheetView.swift
+//  MEWE
+//
+//  Created by Keunna Lee on 2021/02/23.
+//
+
+import SwiftUI
+import PartialSheet
+
+struct CalendarSheetView: View {
+    @EnvironmentObject var partialSheetManager : PartialSheetManager
+    @State var isSheetShown = false
+    var body: some View {
+        
+        Text("CalendarSheetView") // Dummy
+        
+    }
+}

--- a/client/MEWE/MEWE/EmojiMap/View/EmojiMapView.swift
+++ b/client/MEWE/MEWE/EmojiMap/View/EmojiMapView.swift
@@ -6,15 +6,47 @@
 //
 
 import SwiftUI
+import PartialSheet
 
 struct EmojiMapView: View {
+    
+    @EnvironmentObject var partialSheetManager : PartialSheetManager
+    @State var isSheetShown = false
+    
     var body: some View {
-        RoundedBottomNavigationView(destination: TodayView(),
-                                    isRoot: false,
-                                    isLast: true,
-                                    color: .white) {
-            Text("18 April 2019")
-                .setupFont(size: 15, weight: .regular)
+        
+        VStack {
+            GeometryReader { geometry in
+                
+                // Navigation Bar
+                RoundedBottomNavigationView(destination: TodayView(),
+                                            isRoot: false,
+                                            isLast: true) {
+                    HStack {
+                        Text("18 April 2019")
+                            .setupFont(size: 15, weight: .regular)
+                        Image(systemName:SystemImageName.chevronDown)
+                            .resizable()
+                            .frame(width: 15.0, height: 10.0)
+                    }
+                    .onTapGesture {
+                        self.isSheetShown = true
+                    }
+                    
+                }
+                
+                // Search Bar
+                SearchBar()
+                    .padding(.top, geometry.safeAreaInsets.top)
+                Spacer()
+                
+                // Map View
+                Text("Map View will be here")
+                    .partialSheet(isPresented: $isSheetShown) {
+                        Text("This is Calendar Sheet")
+                    }
+                    .addPartialSheet(style: .init(background: .solid(.white), handlerBarColor: .black, enableCover: true, coverColor: Color.black.opacity(0.5), blurEffectStyle: .regular, cornerRadius: 20, minTopDistance: geometry.size.height / 2))
+            }
         }
     }
 }

--- a/client/MEWE/MEWE/EmojiMap/View/SearchBar.swift
+++ b/client/MEWE/MEWE/EmojiMap/View/SearchBar.swift
@@ -1,0 +1,42 @@
+//
+//  SearchBar.swift
+//  MEWE
+//
+//  Created by Keunna Lee on 2021/02/23.
+//
+
+import SwiftUI
+
+struct SearchBar: View {
+    @State var txt = ""
+    let color: Color
+    let cornerRadius: CGFloat
+    
+    init(color: Color = .blue, cornerRadius: CGFloat = 20.0) {
+        self.color = color
+        self.cornerRadius = cornerRadius
+    }
+    var body: some View {
+        HStack{
+            Image(systemName: SystemImageName.magnifyingglass).padding(.horizontal, 8)
+                .foregroundColor(color)
+            
+            TextField("MEWE의 친구를 찾아보세요!", text: self.$txt)
+                .foregroundColor(color)
+            
+            Button(action: {
+                withAnimation { self.txt = "" }
+            }) {
+                Image(systemName: SystemImageName.xmarkCircle).foregroundColor(.black)
+            }
+            .padding(.horizontal, 8)
+        }
+        .padding(10)
+        .overlay(
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .stroke(lineWidth: 2.0)
+                .foregroundColor(color)
+        )
+        .padding(15)
+    }
+}

--- a/client/MEWE/MEWE/Utility/SystemImageName.swift
+++ b/client/MEWE/MEWE/Utility/SystemImageName.swift
@@ -12,4 +12,9 @@ enum SystemImageName {
     static let chevronRight = "chevron.right"
     static let arrowLeft = "arrow.left"
     static let arrowRight = "arrow.right"
+    static let magnifyingglass = "magnifyingglass"
+    static let xmarkCircle = "xmark.circle" // search bar
+    static let arrowBackwardCircleFill = "arrow.backward.circle.fill"
+    static let arrowRightCircleFill = "arrow.right.circle.fill"
+    static let chevronDown = "chevron.down"
 }


### PR DESCRIPTION
## 구현 화면

<img src = "https://user-images.githubusercontent.com/52783516/108750178-10a03600-7584-11eb-9467-da0f33bd19af.png" width = "40%"><img src = "https://user-images.githubusercontent.com/52783516/108750199-1564ea00-7584-11eb-82cf-f601375a9b30.png" width = "40%">

## 구현 기능
1. RoundedBottomNavigationView에서 초기화 시 버튼의 이미지 이름을 설정할 수 있도록 수정 (감정 노트 작성 시 위치를 핀으로 설정하는 곳에서 back/next 버튼 모양이 다르기 때문에 이 때 재사용할 수 있도록 수정)
2. 네비게이션 바 타이틀 부분에 down 이미지 추가(날짜 text 왼쪽) 
3. 네비게이션 바 타이틀 부분을 탭하면 하단에서 화면의 반을 덮는 모달 화면이 나타나도록 구현
4. 색상과 cornerRadius를 설정할 수 있도록 Search Bar 구현
5. Search Bar에서 x 버튼을 누르면 검색어 text 지워짐

## 참고
**partial sheet 사용할 때 주의 사항**
ContentView에서 partial sheet을 사용하는 경우 ContentView를 init할 때 environmentObject로 PartialSheetManager를 설정해야합니다
```swift
import PartialSheet

let sheetManager: PartialSheetManager = PartialSheetManager() // 전역 변수
...
ContentView()
.environmentObject(sheetManager)
```

related Issue #17 